### PR TITLE
Change to be able to specify the easeJS definition path.

### DIFF
--- a/bin/createjs-def
+++ b/bin/createjs-def
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 if (process.argv.length < 4) {
-	console.log("createjs-format <format> <file>");
+	console.log("createjs-format <format> <file> [<easeljs_def_path (for TypeScript only)>]");
 	process.exit();
 }
 var format = process.argv[2];
 var fileName = process.argv[3];
+var easeljsPath = process.argv[4];
 
+if(!easeljsPath){
+	easeljsPath = "easeljs/easeljs.d.ts";
+}
 
 var fs = require("fs");
 
@@ -23,6 +27,6 @@ fs.readFile(fileName, "utf8", function(err, data) {
 	var model = builder.parse(ast[1]);
 
 	var formatter = require("../lib/formatter");
-	var out = formatter[format](model);
+	var out = formatter[format](model, easeljsPath);
 	console.log(out);
 });

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -5,7 +5,7 @@
 var easeljs = { MovieClip:true, Container:true, Shape:true, Bitmap:true, Rectangle:true, Text:true, Shadow:true };
 
 
-function formatTypescript(model) {
+function formatTypescript(model, easeljsPath) {
 
 	var out = "";
 	var known = {};
@@ -51,7 +51,7 @@ function formatTypescript(model) {
 		out += "\t}\n\n";
 	}
 
-	out = "/// <reference path=\"easeljs/easeljs.d.ts\" />\n\n"
+	out = "/// <reference path=\"" + easeljsPath + "\" />\n\n"
 	    + "declare module " + model.namespaces[0] + " {\n\n" 
 	    + out 
 	    + "}\n";


### PR DESCRIPTION
It is more convenient to be able to specify a path of easeljs.d.ts when combined with tsd or dtsm.
